### PR TITLE
chore: upgrade bazel_dep versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,13 +4,13 @@ module(
     compatibility_level = 0,
 )
 
-#bazel_dep(name = "bazel_skylib", version = "1.8.2", dev_dependency = True)
-bazel_dep(name = "bazel_lib", version = "3.0.0", dev_dependency = True)
-bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.8.2", dev_dependency = True)
-bazel_dep(name = "gazelle", version = "0.45.0", dev_dependency = True)
-#bazel_dep(name = "rules_pkg", version = "1.1.0", dev_dependency = True)
+#bazel_dep(name = "bazel_skylib", version = "1.9.0", dev_dependency = True)
+bazel_dep(name = "bazel_lib", version = "3.3.1", dev_dependency = True)
+bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.9.0", dev_dependency = True)
+bazel_dep(name = "gazelle", version = "0.51.3", dev_dependency = True)
+#bazel_dep(name = "rules_pkg", version = "1.2.0", dev_dependency = True)
 
-bazel_dep(name = "rules_multitool", version = "1.8.0")
+bazel_dep(name = "rules_multitool", version = "1.11.1")
 
 multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")
 multitool.hub(


### PR DESCRIPTION
This PR upgrades bazel_dep versions in MODULE.bazel to the latest available in the BCR.

* bazel_skylib: 1.8.2 -> 1.9.0
* bazel_lib: 3.0.0 -> 3.3.1
* bazel_skylib_gazelle_plugin: 1.8.2 -> 1.9.0
* gazelle: 0.45.0 -> 0.51.3
* rules_pkg: 1.1.0 -> 1.2.0
* rules_multitool: 1.8.0 -> 1.11.1